### PR TITLE
Update runtime to 49

### DIFF
--- a/fix-metainfo.diff
+++ b/fix-metainfo.diff
@@ -1,0 +1,28 @@
+diff --git a/data/io.github.sepehr_rs.Sudoku.metainfo.xml.in b/data/io.github.sepehr_rs.Sudoku.metainfo.xml.in
+index 5c53b58..ccc3e34 100644
+--- a/data/io.github.sepehr_rs.Sudoku.metainfo.xml.in
++++ b/data/io.github.sepehr_rs.Sudoku.metainfo.xml.in
+@@ -23,19 +23,19 @@
+ 
+   <screenshots>
+     <screenshot type="default">
+-      <image>https://github.com/sepehr-rs/Sudoku/raw/master/data/screenshots/sudoku.png</image>
++      <image>https://raw.githubusercontent.com/sepehr-rs/Sudoku/dd82b1819691e9994fcb689bf465b5976454ce55/data/screenshots/sudoku.png</image>
+       <caption>Sudoku in light mode</caption>
+     </screenshot>
+     <screenshot>
+-      <image>https://github.com/sepehr-rs/Sudoku/raw/master/data/screenshots/sudoku-dark.png</image>
++      <image>https://raw.githubusercontent.com/sepehr-rs/Sudoku/dd82b1819691e9994fcb689bf465b5976454ce55/data/screenshots/sudoku-dark.png</image>
+       <caption>Sudoku in dark mode</caption>
+     </screenshot>
+     <screenshot>
+-      <image>https://github.com/sepehr-rs/Sudoku/raw/master/data/screenshots/landing-page-dark.png</image>
++      <image>https://raw.githubusercontent.com/sepehr-rs/Sudoku/c15d66297f2c887dac8d41e588794c97b30d1f4e/data/screenshots/landing-page-dark.png</image>
+       <caption>Sudoku landing page in dark mode</caption>
+     </screenshot>
+     <screenshot>
+-      <image>https://github.com/sepehr-rs/Sudoku/raw/master/data/screenshots/landing-page.png</image>
++      <image>https://raw.githubusercontent.com/sepehr-rs/Sudoku/c15d66297f2c887dac8d41e588794c97b30d1f4e/data/screenshots/landing-page.png</image>
+       <caption>Sudoku landing page in light mode</caption>
+     </screenshot>
+   </screenshots>

--- a/io.github.sepehr_rs.Sudoku.json
+++ b/io.github.sepehr_rs.Sudoku.json
@@ -1,7 +1,7 @@
 {
   "app-id": "io.github.sepehr_rs.Sudoku",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "48",
+  "runtime-version": "49",
   "sdk": "org.gnome.Sdk",
   "command": "sudokugame",
   "finish-args": [
@@ -23,18 +23,6 @@
   ],
   "modules": [
       "python3-requirements.json",
-      {
-          "name": "blueprint-compiler",
-          "buildsystem": "meson",
-          "cleanup": ["*"],
-          "sources": [
-              {
-                  "type": "git",
-                  "url": "https://gitlab.gnome.org/GNOME/blueprint-compiler",
-                  "tag": "0.18.0"
-              }
-          ]
-      },
       {
           "name": "sudokugame",
           "buildsystem": "meson",

--- a/io.github.sepehr_rs.Sudoku.json
+++ b/io.github.sepehr_rs.Sudoku.json
@@ -32,6 +32,10 @@
                   "type": "git",
                   "url": "https://github.com/sepehr-rs/Sudoku.git",
                   "commit": "242e86b9aee3926a0e68cb21e2be096710430f5a"
+              },
+              {
+                  "type": "patch",
+                  "path": "fix-metainfo.diff"
               }
           ]
       }


### PR DESCRIPTION
`blueprint-compiler` is in the Sdk now and can be removed